### PR TITLE
[UI-2106] unmount vue component on wrapper unmount

### DIFF
--- a/lib/vue-wrapper/index.js
+++ b/lib/vue-wrapper/index.js
@@ -181,7 +181,12 @@ export default function wrap(Component) {
           self._mounted = true;
         },
         unmounted() {
-          self._mounted = false;
+          if (self._mounted) {
+            setTimeout(() => {
+              self._mounted = false;
+              self._wrapper.unmount();
+            });
+          }
         },
       });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueshift/ng-interop",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "interoperability between Vue and angular.js",
   "author": "Alexander Simonides",
   "repository": {


### PR DESCRIPTION
### Description
Fixes the vue components not getting unmounted by unmounting its wrapper component.

### Test Cases
- [x] make sure all the lifecycle method of vue component gets called